### PR TITLE
JDBCで"全件検索"機能を追加。

### DIFF
--- a/RaiseTech08/src/main/java/com/example/demo/controller/ShoppingController.java
+++ b/RaiseTech08/src/main/java/com/example/demo/controller/ShoppingController.java
@@ -1,0 +1,34 @@
+package com.example.demo.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.example.demo.entity.ShoppingList;
+import com.example.demo.service.ShoppingService;
+
+/**
+ * @author maetaku
+ *買い物リストアプリコントローラ
+ */
+
+@Controller
+public class ShoppingController {
+	@Autowired
+	ShoppingService service;
+	
+	/**
+	 * 買い物リスト一覧を出力する
+	 * @param model
+	 * @return　list一覧
+	 */
+	@GetMapping("/list")
+	String list(Model model) {
+		List<ShoppingList> shoppingLists = service.findAll();
+		model.addAttribute("list", shoppingLists);
+		return "list";
+	}
+}

--- a/RaiseTech08/src/main/java/com/example/demo/entity/ShoppingList.java
+++ b/RaiseTech08/src/main/java/com/example/demo/entity/ShoppingList.java
@@ -13,7 +13,7 @@ public class ShoppingList {
 	private String name;
 	
 	@NotNull
-	private Integer quantity;
+	private int quantity;
 	
 	@NotNull
 	private int price;	

--- a/RaiseTech08/src/main/java/com/example/demo/service/ShoppingService.java
+++ b/RaiseTech08/src/main/java/com/example/demo/service/ShoppingService.java
@@ -1,0 +1,37 @@
+package com.example.demo.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import com.example.demo.entity.ShoppingList;
+
+/**
+ * Spring JDBC のサービスクラス
+ * @author maetaku
+ */
+
+@Service
+public class ShoppingService {
+	
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+	
+	/**
+	 * 全件検索メソッド
+	 *@return 全件
+	 */
+	
+	public List<ShoppingList> findAll(){
+		
+		//SQL
+		String query = "SELECT * FROM shopping_list";
+		
+		List<ShoppingList> shoppingLists = jdbcTemplate.query(query, new BeanPropertyRowMapper<>(ShoppingList.class));
+		
+		return shoppingLists;
+	}
+}

--- a/RaiseTech08/src/main/resources/application.properties
+++ b/RaiseTech08/src/main/resources/application.properties
@@ -1,1 +1,13 @@
+# datasource
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.sql.init.mode=always
+spring.sql.init.schema-locations=classpath:schema.sql
+spring.sql.init.data-locations=classpath:data.sql
+spring.sql.init.encoding=utf-8
 
+spring.h2.console.enabled=true
+
+#spring.jpa.show-sql=true

--- a/RaiseTech08/src/main/resources/templates/list.html
+++ b/RaiseTech08/src/main/resources/templates/list.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+<meta charset="UTF-8">
+<title>[JDBC]買い物リスト一覧 </title>
+</head>
+<body>
+	<h2>[JDBC]買い物リスト一覧</h2>
+	<table>
+		<tr>
+			<th>ID</th>
+			<th>品目</th>
+			<th>数量</th>
+			<th>値段</th>
+		</tr>
+		<tr th:each="All : ${list}">
+			<td th:text="${All.id}"></td>
+			<td th:text="${All.name}"></td>
+			<td th:text="${All.quantity}"></td>
+			<td th:text="${All.price}"></td>
+		</tr>
+	</table>
+	<a th:href="@{/top}">トップ画面へ</a>
+</body>
+</html>

--- a/RaiseTech08/src/test/java/com/example/demo/service/ShoppingServiceTest.java
+++ b/RaiseTech08/src/test/java/com/example/demo/service/ShoppingServiceTest.java
@@ -1,0 +1,33 @@
+package com.example.demo.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.example.demo.entity.ShoppingList;
+
+@SpringBootTest
+class ShoppingServiceTest {
+
+	@Autowired
+	ShoppingService target;
+	
+	@Test
+	void 全件出力_8件あることを確認() {
+		System.out.println("*** JDBC READ Test started. ***");
+		
+		//全件検索
+		List<ShoppingList> actual = target.findAll();
+		System.out.println("全件データ数； " + actual.size());
+		
+		//全件＝8件あることを確認。
+		assertThat(actual.size()).isEqualTo(8);
+		
+		System.out.println("*** JDBC READ Test ended. ***");
+	}
+
+}


### PR DESCRIPTION
## 参照先
* (https://github.com/mae-taku/RaiseTech08/issues/4)

## やったこと

* JDBCで全件検索を行い、画面に出力する。
* 動作確認用、テストコードを追加。

## やらないこと

* MyBatisの導入。

## できるようになること

* H2DBに登録された初期データを画面出力できる。

## できなくなること

* 無し。

## 動作確認

* 「http://localhost:8080/list」にアクセスすると、初期データ全件が出力される。
* JUnitテストでも、初期データが8件あることを確認できる。